### PR TITLE
Provides zprint action

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Detailed documentation on how to use each action located on their folder.
 <!-- markdownlint-disable MD013 -->
 | Action                       | Description                   | Lint on Push | Fix with Review   | Autofix on Push   |
 |------------------------------|-------------------------------|--------------|-------------------|-------------------|
-| [cljfmt](cljfmt)             | Clojure formatter             | x            | x                 | x                 |
 | [clippy](clippy)             | Rust linter                   | x            | x (Partial fixes) | x (Partial fixes) |
+| [cljfmt](cljfmt)             | Clojure formatter             | x            | x                 | x                 |
 | [dartfmt](dartfmt)           | Dart (and Flutter) formatter  | x            | x                 | x                 |
 | [pwshfmt](pwshfmt)           | Powershell Formatter          | x            | x                 | x                 |
 | [rubocop](rubocop)           | Ruby linter                   | x            | x                 | x                 |
 | [rustfmt](rustfmt)           | Rust formatter                | x            | x                 | x                 |
 | [shfmt](shfmt)               | Shell formatter               | x            | x                 | x                 |
 | [tslint](tslint)             | TypeScript lint and formatter | x            | x                 | x                 |
+| [zprint](zprint)             | Clojure formatter             | x            | x                 | x                 |
 | [dartanalyzer](dartanalyzer) | Dart (and Flutter) linter     | x            |                   |                   |
 | [hadolint](hadolint)         | Dockerfile linter             | x            |                   |                   |
 | [kubeval](kubeval)           | Kubernets (k8s) linter        | x            |                   |                   |

--- a/cljfmt/README.md
+++ b/cljfmt/README.md
@@ -11,6 +11,9 @@ as well as any variable needed to access all the dependencies of the project.
 Given that this plugin uses `lein cljfmt`, it might need extra environment
 variable and secrets, such as `AWS_ACCESS_KEY_ID` and `AWS_ACCESS_KEY_KEY`.
 
+If you'd rather not install the dependencies, and prefer to use an external tool
+instead of a plugin, check [zprint](../zprint).
+
 ## Fixes on Pull Request review
 
 This action provides automated fixes using Pull Request review comments.

--- a/zprint/Dockerfile
+++ b/zprint/Dockerfile
@@ -9,9 +9,6 @@ LABEL "repository"="http://github.com/bltavares/actions"
 LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
-RUN echo '{:search-config? true}' > ~/.zprint.edn \
-  && boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help
-
 RUN apk --no-cache add \
   curl=7.61.1-r1 \
   jq=1.6_rc1-r1 \

--- a/zprint/Dockerfile
+++ b/zprint/Dockerfile
@@ -10,7 +10,7 @@ LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
 RUN echo '{:search-config? true}' > ~/.zprint.edn \
-  && boot -d boot-fmt:0.1.8 fmt --help
+  && boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help
 
 RUN apk --no-cache add \
   curl=7.61.1-r1 \

--- a/zprint/Dockerfile
+++ b/zprint/Dockerfile
@@ -1,0 +1,23 @@
+FROM clojure:boot-alpine
+
+LABEL "com.github.actions.name"="zprint"
+LABEL "com.github.actions.description"="Provides linting and fixes using zprint"
+LABEL "com.github.actions.icon"="user-check"
+LABEL "com.github.actions.color"="purple"
+
+LABEL "repository"="http://github.com/bltavares/actions"
+LABEL "homepage"="http://github.com/bltavares/actions"
+LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
+
+RUN echo '{:search-config? true}' > ~/.zprint.edn \
+  && boot -d boot-fmt:0.1.8 fmt --help
+
+RUN apk --no-cache add \
+  curl=7.61.1-r1 \
+  jq=1.6_rc1-r1 \
+  bash=4.4.19-r1 \
+  git=2.18.1-r0
+
+COPY lib.sh /lib.sh
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/zprint/README.md
+++ b/zprint/README.md
@@ -1,0 +1,48 @@
+# zprint action
+
+## Validations on Push
+
+This actions will check the formating of the project, using
+[boot-fmt](https://github.com/pesterhazy/boot-fmt).
+
+In contrast of [cljfmt](../cljfmt), this action does not require installation of
+the projects dependencies, as it has global execution access.
+
+The container configures [zprint](https://github.com/kkinnear/zprint) to search
+for configuration files in the current project, allowing you to commit the
+formatting rules as part of the project.
+
+For more configuration details, check upstream
+[documentation](https://github.com/kkinnear/zprint#how-to-configure-zprint)
+
+## Fixes on Pull Request review
+
+This action provides automated fixes using Pull Request review comments.
+
+If the comment starts with `fix $action_name` or `fix zprint`, a new commit will
+be added to the branch with the automated fixes applied.
+
+**Supports**: autofix on push
+
+## Example workflow
+
+```hcl
+workflow "on push" {
+  on = "push"
+  resolves = ["zprint"]
+}
+
+# Used for fix on review
+workflow "on review" {
+  resolves = ["zprint"]
+  on = "pull_request_review"
+}
+
+action "zprint" {
+  uses = "bltavares/actions/zprint@master"
+  # Enable autofix on push
+  # args = ["autofix"]
+  # Used for pushing changes for `fix` comments on review
+  secrets = ["GITHUB_TOKEN"]
+}
+```

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -13,4 +13,10 @@ lint() {
 	boot -d boot-fmt -d zprint fmt --git --mode list
 }
 
+setup() {
+    echo '{:search-config? true}' > ~/.zprint.edn \
+        && boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help > /dev/null
+}
+
+setup
 _lint_and_fix_action zprint "${@}"

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -14,7 +14,8 @@ lint() {
 }
 
 setup() {
-	boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help >/dev/null
+	echo '{:search-config? true}' >~/.zprint.edn &&
+		boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help >/dev/null
 }
 
 setup

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source /lib.sh
+
+fix() {
+    boot -d boot-fmt fmt --git --mode overwrite --really
+}
+
+lint() {
+    boot -d boot-fmt fmt --git --mode list
+}
+
+_lint_and_fix_action zprint "${@}"

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 source /lib.sh
 
 fix() {
-  boot -d boot-fmt -d zprint fmt --git --mode overwrite --really
+	boot -d boot-fmt -d zprint fmt --git --mode overwrite --really
 }
 
 lint() {
-    boot -d boot-fmt -d zprint fmt --git --mode list
+	boot -d boot-fmt -d zprint fmt --git --mode list
 }
 
 _lint_and_fix_action zprint "${@}"

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 source /lib.sh
 
 fix() {
-	boot -d boot-fmt fmt --git --mode overwrite --really
+  boot -d boot-fmt -d zprint fmt --git --mode overwrite --really
 }
 
 lint() {
-	boot -d boot-fmt fmt --git --mode list
+    boot -d boot-fmt -d zprint fmt --git --mode list
 }
 
 _lint_and_fix_action zprint "${@}"

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 source /lib.sh
 
 fix() {
-    boot -d boot-fmt fmt --git --mode overwrite --really
+	boot -d boot-fmt fmt --git --mode overwrite --really
 }
 
 lint() {
-    boot -d boot-fmt fmt --git --mode list
+	boot -d boot-fmt fmt --git --mode list
 }
 
 _lint_and_fix_action zprint "${@}"

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -14,8 +14,7 @@ lint() {
 }
 
 setup() {
-    echo '{:search-config? true}' > ~/.zprint.edn \
-        && boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help > /dev/null
+	boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help >/dev/null
 }
 
 setup

--- a/zprint/lib.sh
+++ b/zprint/lib.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+_requires_token() {
+	if [[ -z $GITHUB_TOKEN ]]; then
+		echo "Set the GITHUB_TOKEN env variable."
+		exit 1
+	fi
+}
+
+_should_fix_issue() {
+	pr_url="$(jq --raw-output '.issue.pull_request.url | select(. != null)' "$GITHUB_EVENT_PATH")"
+	fix_comment="$(jq --raw-output ".comment.body | select(. | startswith(\"$1\"))" "$GITHUB_EVENT_PATH")"
+	[[ -n $pr_url ]] && [[ -n $fix_comment ]] || exit 0
+}
+
+__switch_to_branch() {
+	# TODO: Not working yet
+	remote_branch_name=$(git name-rev --name-only "${GITHUB_SHA}")
+	git checkout -b "${remote_branch_name#remotes/origin}" --track "$remote_branch_name"
+}
+
+_should_fix_review() {
+	fix_comment="$(jq --raw-output ".review.body | select(. | startswith(\"$1\"))" "$GITHUB_EVENT_PATH")"
+	[[ -n $fix_comment ]] || exit 0
+}
+
+_git_is_dirty() {
+	[[ -n "$(git status -s)" ]]
+}
+
+_local_commit() {
+	git config --global user.name "github-actions[bot]"
+	git config --global user.email "github-actions[bot]@users.noreply.github.com"
+	git add .
+	git commit -m "${GITHUB_ACTION}: lint fix"
+}
+
+_remote_commit() {
+	tmp_file="$(mktemp)"
+
+	# shellcheck disable=SC2034  # Unused variables left for readability
+	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
+		file_payload="{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}"
+		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
+			-d "$file_payload" \
+			"https://api.github.com/repos/${GITHUB_REPOSITORY}/git/blobs")
+		echo "{ \"mode\": \"${dst_mode}\", \"path\": \"${path}\", \"sha\": $(jq '.sha' <<<"$file_response")}" >>"$tmp_file"
+	done < <(git diff-files)
+
+	head_response="$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
+		-X GET \
+		"https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}")"
+	head_sha="$(jq '.object.sha' <<<"$head_response")"
+
+	tree_payload="{\"base_tree\": ${head_sha}, \"tree\": $(jq -s '.' "$tmp_file")}"
+	tree_response="$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
+		-d "$tree_payload" \
+		"https://api.github.com/repos/${GITHUB_REPOSITORY}/git/trees")"
+
+	commit_payload="{\"message\": \"${GITHUB_ACTION}: lint fix\", \"tree\": $(jq '.sha' <<<"$tree_response"), \"parents\": [${head_sha}]}"
+	commit_response="$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
+		-d "$commit_payload" \
+		"https://api.github.com/repos/${GITHUB_REPOSITORY}/git/commits")"
+
+	update_branch_payload="{\"sha\": $(jq '.sha' <<<"$commit_response")}"
+	# shellcheck disable=SC2034  # Unused variables left for readability
+	update_branch_response="$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
+		-d "$update_branch_payload" \
+		-X PATCH \
+		"https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}")"
+
+}
+
+_commit_if_needed() {
+	if _git_is_dirty; then
+		_remote_commit
+		_local_commit
+	fi
+}
+
+_lint_and_fix_action() {
+	if [[ $GITHUB_EVENT_NAME == "push" ]]; then
+		if [[ ${2:-} == "autofix" ]]; then
+			_requires_token
+			fix
+			_commit_if_needed
+			lint
+		else
+			lint
+		fi
+	elif [[ $GITHUB_EVENT_NAME == "pull_request_review" ]]; then
+		_requires_token
+		_should_fix_review "fix $GITHUB_ACTION" || _should_fix_review "fix $1"
+		fix
+		_commit_if_needed
+	fi
+
+}
+
+_lint_action() {
+	if [[ ${GITHUB_EVENT_NAME} == "push" ]]; then
+		lint "${@}"
+	fi
+}


### PR DESCRIPTION
While `cljfmt` is wide adopted, there is a little inconvenience: it must
be installed as a plugin on the project, requiring the installation of
dependencies to run.

An alternative is `zprint`, which is has a very convenient global CLI
alternative through `boot-fmt`. `zprint` has a lot of knobs to adjust on
the formatting, and using `boot-fmt` allows for formatting without
dependencies being installed.

This commit creates the new action providing `zprint` as a formatter.