### PR TITLE
Use cljfmt without installing projects dependency

### DIFF
--- a/cljfmt/Dockerfile
+++ b/cljfmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:lein-alpine
+FROM clojure:tools-deps-alpine
 
 LABEL "com.github.actions.name"="cljfmt"
 LABEL "com.github.actions.description"="Provides linting and fixes using cljfmt"
@@ -8,6 +8,8 @@ LABEL "com.github.actions.color"="purple"
 LABEL "repository"="http://github.com/bltavares/actions"
 LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
+
+RUN clojure -Sdeps '{:deps {lein-cljfmt {:mvn/version "0.6.4"}}}' -e ':ok'
 
 RUN apk --no-cache add \
   curl=7.61.1-r1 \

--- a/cljfmt/README.md
+++ b/cljfmt/README.md
@@ -10,10 +10,16 @@ execution of `cljfmt` without needing to use the `lein` plugin. This way, you
 are able to format the project without providing access to any project
 dependencies.
 
-For configuration, this action will inspect the existence of the following files on the project, and pass them in to `cljfmt`:
+For configuration, this action will inspect the existence of the following files
+on the project, and pass them in to `cljfmt`:
 
-- `.cljfmt-alias.edn`: [:alias-map](https://github.com/weavejester/cljfmt#configuration) configuration declarations
-- `.cljfmt-indent.edn`: [:indents](https://github.com/weavejester/cljfmt#indentation-rules) configuration declarations
+- `.cljfmt-alias.edn`
+  [:alias-map](https://github.com/weavejester/cljfmt#configuration) map config
+  content
+
+- `.cljfmt-indent.edn`
+  [:indents](https://github.com/weavejester/cljfmt#indentation-rules) map config
+  content
 
 Alternatively, there is [zprint](../zprint) action available.
 

--- a/cljfmt/README.md
+++ b/cljfmt/README.md
@@ -2,17 +2,20 @@
 
 ## Validations on Push
 
-This actions will check the formating of the project, using
+This actions will check the formatting of the project, using
 [cljfmt](https://github.com/weavejester/cljfmt).
 
-`cljfmt` plugin required to be installed on your project,
-as well as any variable needed to access all the dependencies of the project.
+This action make use of `tool.deps` instead of `lein`, which provides global
+execution of `cljfmt` without needing to use the `lein` plugin. This way, you
+are able to format the project without providing access to any project
+dependencies.
 
-Given that this plugin uses `lein cljfmt`, it might need extra environment
-variable and secrets, such as `AWS_ACCESS_KEY_ID` and `AWS_ACCESS_KEY_KEY`.
+For configuration, this action will inspect the existence of the following files on the project, and pass them in to `cljfmt`:
 
-If you'd rather not install the dependencies, and prefer to use an external tool
-instead of a plugin, check [zprint](../zprint).
+- `.cljfmt-alias.edn`: [:alias-map](https://github.com/weavejester/cljfmt#configuration) configuration declarations
+- `.cljfmt-indent.edn`: [:indents](https://github.com/weavejester/cljfmt#indentation-rules) configuration declarations
+
+Alternatively, there is [zprint](../zprint) action available.
 
 ## Fixes on Pull Request review
 

--- a/cljfmt/entrypoint.sh
+++ b/cljfmt/entrypoint.sh
@@ -7,26 +7,26 @@ source /lib.sh
 declare -a file_args=()
 
 cljfmt() {
-    clojure -Sdeps '{:deps {lein-cljfmt {:mvn/version "0.6.4"}}}' \
-            -m cljfmt.main "${file_args[@]}" "$@"
+	clojure -Sdeps '{:deps {lein-cljfmt {:mvn/version "0.6.4"}}}' \
+		-m cljfmt.main "${file_args[@]}" "$@"
 }
 
 fix() {
-    cljfmt fix
+	cljfmt fix
 }
 
 lint() {
-    cljfmt check
+	cljfmt check
 }
 
 setup_files() {
-    if [[ -f .cljfmt-indents.edn ]]; then
-        file_args+=(--indents .cljfmt-indents.edn)
-    fi
+	if [[ -f .cljfmt-indents.edn ]]; then
+		file_args+=(--indents .cljfmt-indents.edn)
+	fi
 
-    if [[ -f .cljfmt-alias.edn ]]; then
-        file_args+=(--alias-map .cljfmt-alias.edn)
-    fi
+	if [[ -f .cljfmt-alias.edn ]]; then
+		file_args+=(--alias-map .cljfmt-alias.edn)
+	fi
 }
 
 setup_files

--- a/cljfmt/entrypoint.sh
+++ b/cljfmt/entrypoint.sh
@@ -4,13 +4,30 @@ set -euo pipefail
 
 # shellcheck disable=SC1091
 source /lib.sh
+declare -a file_args=()
+
+cljfmt() {
+    clojure -Sdeps '{:deps {lein-cljfmt {:mvn/version "0.6.4"}}}' \
+            -m cljfmt.main "${file_args[@]}" "$@"
+}
 
 fix() {
-	lein cljfmt fix
+    cljfmt fix
 }
 
 lint() {
-	lein cljfmt check
+    cljfmt check
 }
 
+setup_files() {
+    if [[ -f .cljfmt-indents.edn ]]; then
+        file_args+=(--indents .cljfmt-indents.edn)
+    fi
+
+    if [[ -f .cljfmt-alias.edn ]]; then
+        file_args+=(--alias-map .cljfmt-alias.edn)
+    fi
+}
+
+setup_files
 _lint_and_fix_action cljfmt "${@}"

--- a/zprint/Dockerfile
+++ b/zprint/Dockerfile
@@ -9,6 +9,8 @@ LABEL "repository"="http://github.com/bltavares/actions"
 LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
+RUN echo '{:search-config? true}' >~/.zprint.edn \
+  && boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help >/dev/null
 RUN apk --no-cache add \
   curl=7.61.1-r1 \
   jq=1.6_rc1-r1 \

--- a/zprint/README.md
+++ b/zprint/README.md
@@ -2,11 +2,8 @@
 
 ## Validations on Push
 
-This actions will check the formating of the project, using
+This actions will check the formatting of the project, using
 [boot-fmt](https://github.com/pesterhazy/boot-fmt).
-
-In contrast of [cljfmt](../cljfmt), this action does not require installation of
-the projects dependencies, as it has global execution access.
 
 The container configures [zprint](https://github.com/kkinnear/zprint) to search
 for configuration files in the current project, allowing you to commit the
@@ -14,6 +11,8 @@ formatting rules as part of the project.
 
 For more configuration details, check upstream
 [documentation](https://github.com/kkinnear/zprint#how-to-configure-zprint)
+
+Alternatively, there is also [cljfmt](../cljfmt) action available.
 
 ## Fixes on Pull Request review
 

--- a/zprint/entrypoint.sh
+++ b/zprint/entrypoint.sh
@@ -13,10 +13,4 @@ lint() {
 	boot -d boot-fmt -d zprint fmt --git --mode list
 }
 
-setup() {
-	echo '{:search-config? true}' >~/.zprint.edn &&
-		boot -d boot-fmt:0.1.8 -d zprint:0.4.15 fmt --help >/dev/null
-}
-
-setup
 _lint_and_fix_action zprint "${@}"


### PR DESCRIPTION
When using `cljfmt` action, we ended up downloading all the dependencies
of the project, as it would be integrated as a `lein` plugin.

This was cumbersome, as it required exposing extra configuration to
access the project's dependencies as well. Ideally, to reduce the
adoption, it would be better to use `cljfmt` as a globally accessible
tool, without the need to access the project's dependencies from GitHub
Actions' execution environment.

There is a [previously undocumented feature](https://github.com/weavejester/cljfmt/pull/164)
on `cljfmt` which exposes it as a `deps-tools` executable.

This commit refactors the execution to run the formatter from a global
execution path. This means we don't need extra access to the project
dependencies.

The configuration to use the formatter don't live anymore inside
`lein`'s `project.clj`, and now is expected to live on their own
file inside the project, as it is documented.

We are also taking a chance to refactor a couple of things on the
`zprint` action, which is somewhat complementary to `cljfmt`.