### PR TITLE
Loose version selection rules for Alpine packages

### DIFF
--- a/cljfmt/Dockerfile
+++ b/cljfmt/Dockerfile
@@ -10,10 +10,10 @@ LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/hadolint/Dockerfile
+++ b/hadolint/Dockerfile
@@ -13,10 +13,10 @@ LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 COPY --from=hadolint /bin/hadolint /bin/hadolint
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/kubeval/Dockerfile
+++ b/kubeval/Dockerfile
@@ -13,10 +13,10 @@ LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 COPY --from=kubeval /kubeval /bin/kubeval
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/mdlint/Dockerfile
+++ b/mdlint/Dockerfile
@@ -12,10 +12,10 @@ LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 RUN npm install -g markdownlint-cli@0.13.0
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/pwshfmt/Dockerfile
+++ b/pwshfmt/Dockerfile
@@ -13,10 +13,10 @@ RUN pwsh -c 'Install-Module -Name PowerShell-Beautifier -Force'
 RUN pwsh -c 'Import-Module PowerShell-Beautifier.psd1'
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/shellcheck/Dockerfile
+++ b/shellcheck/Dockerfile
@@ -10,10 +10,10 @@ LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/shfmt/Dockerfile
+++ b/shfmt/Dockerfile
@@ -13,10 +13,10 @@ LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 COPY --from=shfmt /bin/shfmt /bin/shfmt
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/tslint/Dockerfile
+++ b/tslint/Dockerfile
@@ -12,10 +12,10 @@ LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 RUN npm install -g tslint@5.12.1 typescript@3.2.4
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/zprint/Dockerfile
+++ b/zprint/Dockerfile
@@ -10,10 +10,10 @@ LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
 RUN apk --no-cache add \
-  curl=7.61.1-r1 \
-  jq=1.6_rc1-r1 \
-  bash=4.4.19-r1 \
-  git=2.18.1-r0
+  curl~=7 \
+  jq~=1.6 \
+  bash~=4 \
+  git~=2
 
 COPY lib.sh /lib.sh
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
A recent update of Alpine package repositories broke the actions based on the
alpine image.

Today I've learned that Alpine don't keep older versions around. To avoid it
breaking again, I'm using the `~=` matcher instead of the strict `=` version
selector.

Using `~=` is valid for `hadolint` as well.

Closes #12