### PR TITLE
Make file_payload writable

### DIFF
--- a/bash/lib.sh
+++ b/bash/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/clippy/lib.sh
+++ b/clippy/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/clj-autoupdate/lib.sh
+++ b/clj-autoupdate/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/cljfmt/lib.sh
+++ b/cljfmt/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/dartanalyzer/lib.sh
+++ b/dartanalyzer/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/dartfmt/lib.sh
+++ b/dartfmt/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/hadolint/lib.sh
+++ b/hadolint/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/kubeval/lib.sh
+++ b/kubeval/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/lib.sh
+++ b/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/mdlint/lib.sh
+++ b/mdlint/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/prettier/lib.sh
+++ b/prettier/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/pwshfmt/lib.sh
+++ b/pwshfmt/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/rubocop/lib.sh
+++ b/rubocop/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/rustfmt/lib.sh
+++ b/rustfmt/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/shellcheck/lib.sh
+++ b/shellcheck/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/shfmt/lib.sh
+++ b/shfmt/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/terraform/lib.sh
+++ b/terraform/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/tslint/lib.sh
+++ b/tslint/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \

--- a/zprint/lib.sh
+++ b/zprint/lib.sh
@@ -56,7 +56,7 @@ _remote_commit() {
 
 	# shellcheck disable=SC2034  # Unused variables left for readability
 	while read -r _src_mode dst_mode _src_sha dst_sha flag path; do
-		local -r file_payload="$(mktemp)"
+		file_payload="$(mktemp)"
 		echo "{\"encoding\": \"base64\", \"content\": \"$(base64 "$path" | tr -d '\n')\"}" >"$file_payload"
 		file_response=$(curl --fail -H "Authorization: token ${GITHUB_TOKEN}" \
 			-d @"$file_payload" \


### PR DESCRIPTION
Using `local` binds to a local variable that is readonly thus output can
    be redirected to this file.

Error:
```
/lib.sh: line 59: local: file_payload: readonly variable
```