### PR TITLE
Add an option to pass shfmt arguments

### DIFF
--- a/shfmt/README.md
+++ b/shfmt/README.md
@@ -38,3 +38,7 @@ action "shfmt" {
   secrets = ["GITHUB_TOKEN"]
 }
 ```
+
+## Environment Variables
+
+* `SHFMT_ARGS` Additional command-line parameters passed to shfmt

--- a/shfmt/entrypoint.sh
+++ b/shfmt/entrypoint.sh
@@ -5,12 +5,16 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source /lib.sh
 
+if [ -z "${SHFMT_ARGS:-}" ]; then
+	SHFMT_ARGS=""
+fi
+
 fix() {
-	shfmt -s -w .
+	shfmt -s -w ${SHFMT_ARGS} .
 }
 
 lint() {
-	shfmt -s -l -d .
+	shfmt -s -l -d ${SHFMT_ARGS} .
 }
 
 _lint_and_fix_action shfmt "${@}"

--- a/shfmt/entrypoint.sh
+++ b/shfmt/entrypoint.sh
@@ -10,7 +10,7 @@ if [ -z "${SHFMT_ARGS:-}" ]; then
 fi
 
 fix() {
-	shfmt -s -w ${SHFMT_ARGS} .
+	shfmt -s -w ${SHFMT_ARGS:-} .
 }
 
 lint() {


### PR DESCRIPTION
I've added a env variable to pass argument to the shfmt tool as I need to pass the indentation options.