### PR TITLE
Use latest Terraform

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -12,7 +12,7 @@ LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 RUN apk --no-cache add \
   curl~=7 \
   jq~=1.6 \
-  bash~=4 \
+  bash~=5 \
   git~=2
 
 COPY lib.sh /lib.sh

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.0-beta2
+FROM hashicorp/terraform:light
 
 LABEL "com.github.actions.name"="terraform"
 LABEL "com.github.actions.description"="Provides linting and fixes using terraform fmt"


### PR DESCRIPTION
The used Terraform image was an old beta. Meanwhile multiple versions of Terraform were released, some [even adding different formatting rules](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md).

To be up to date on formatting, the `light` image can be used which will always have the latest stable Terraform version. 
That image comes with newer bash and fails though:
```
Step 9/12 : RUN apk --no-cache add   curl~=7   jq~=1.6   bash~=4   git~=2
 ---> Running in 5484859b74d0
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  bash-5.0.0-r0:
    breaks: world[bash~4]
The command ‘/bin/sh -c apk --no-cache add   curl~=7   jq~=1.6   bash~=4   git~=2’ returned a non-zero code: 1
```

This PR also bumps `bash` to `v5`. Is that ok? Is there a specific reason why `bash~=4` was used? 
Should I bump it to this version in all other actions too?