### PR TITLE
update rustfmt dockerfile to use 1.40-slim

### DIFF
--- a/rustfmt/Dockerfile
+++ b/rustfmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.32-slim
+FROM rust:1.40-slim
 
 LABEL "com.github.actions.name"="rustfmt"
 LABEL "com.github.actions.description"="Provides formating and fixes for Rust using rustfmt"


### PR DESCRIPTION
Ideally this would point to `stable-slim` but there doesn't seem to be an option for that.