### PR TITLE
Fix cljfmt fix on PR review, update README with more examples

### DIFF
--- a/cljfmt/README.md
+++ b/cljfmt/README.md
@@ -21,31 +21,90 @@ on the project, and pass them in to `cljfmt`:
   [:indents](https://github.com/weavejester/cljfmt#indentation-rules) map config
   content
 
-Alternatively, there is [zprint](../zprint) action available.
-
-## Fixes on Pull Request review
-
-This action provides automated fixes using Pull Request review comments.
-
-If the comment starts with `fix $action_name` or `fix cljfmt`, a new commit will
-be added to the branch with the automated fixes applied.
-
-**Supports**: autofix on push
-
-## Example workflow
+In order to pass root level configuration parameter to `cljfmt`, it needs to be specified in workflow YAML via args.
 
 ```yaml
 name: Clojure linter
 on:
-  push # change to "pull_request_review" for running on PR reviews
+  push
+jobs:
+  clojureLint:
+    runs-on: ubuntu-latest
+steps:
+  - uses: actions/checkout@v2
+  - uses: bltavares/actions/cljfmt@1.0.10
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      args: src test extra-src-path --no-remove-consecutive-blank-lines
+```
+
+More `cljfmt` options can be found [here](https://github.com/weavejester/cljfmt/blob/master/cljfmt/src/cljfmt/main.clj#L169-L200).
+
+## Validations on Pull Request
+
+Start lint action each time when PR opened or source branch updated (synchronize).
+
+```yaml
+name: Clojure linter
+on:
+  pull_request:
+    types: [opened, synchronize]
 jobs:
   clojureLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: bltavares/actions/cljfmt@1.0.8
+      - uses: actions/checkout@v2
+      - uses: bltavares/actions/cljfmt@1.0.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: src test extra-src-path
+```
+
+## Fixes on Push
+
+This action provides automated fixes, action will start on push event and a new commit will be added to the branch with the automated fixes applied.
+
+```yaml
+name: Clojure linter
+on:
+  push
+jobs:
+  clojureLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bltavares/actions/cljfmt@1.0.10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: autofix src test extra-src-path
 ```
+
+## Fixes on Pull Request review
+
+Action will start when PR review submitted and if the comment starts with `fix $action_name` or `fix cljfmt`, a new commit will be added to the branch with the automated fixes applied.
+
+```yaml
+name: Clojure linter
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  cljfmt:
+    runs-on: ubuntu-latest
+    # skip running unless comment starts with `fix cljfmt`
+    if: ${{ startsWith( github.event.review.body, 'fix cljfmt' )}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bltavares/actions/cljfmt@1.0.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass PR head ref for Pull Request review, required for autofix commit
+          GITHUB_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        with:
+          args: autofix src test extra-src-path
+```
+
+Alternatively, there is [zprint](../zprint) action available.


### PR DESCRIPTION
Fixes `cljfmt` fix on PR review, problems were:
 - On `pull_request`the env var `GITHUB_REF `points to PR merge branch `refs/pull/:prNumber/merge` and `_remote_commit` fails, fixed by using `GITHUB_HEAD_REF`.
 - On `pull_request_review` these are empty, and we need to parse PR head ref from action event and pass it via new env var `GITHUB_PR_HEAD_REF`, added as an example to README.