### PR TITLE
Bump versions on cljfmt action

### DIFF
--- a/cljfmt/Dockerfile
+++ b/cljfmt/Dockerfile
@@ -9,12 +9,12 @@ LABEL "repository"="http://github.com/bltavares/actions"
 LABEL "homepage"="http://github.com/bltavares/actions"
 LABEL "maintainer"="Bruno Tavares <connect+githubactions@bltavares.com>"
 
-RUN clojure -Sdeps '{:deps {lein-cljfmt {:mvn/version "0.6.4"}}}' -e ':ok'
+RUN clojure -Sdeps '{:deps {lein-cljfmt {:mvn/version "0.8.2"}}}' -e ':ok'
 
 RUN apk --no-cache add \
   curl~=7 \
   jq~=1.6 \
-  bash~=4 \
+  bash~=5 \
   git~=2
 
 COPY lib.sh /lib.sh


### PR DESCRIPTION
Dockerfile build was failing with
```
  Step 10/13 : RUN apk --no-cache add   curl~=7   jq~=1.6   bash~=4   git~=2
   ---> Running in 8d5301dfd70c
  fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
  fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
  ERROR: unable to select packages:
    bash-5.1.16-r2:
      breaks: world[bash~4]
  The command '/bin/sh -c apk --no-cache add   curl~=7   jq~=1.6   bash~=4   git~=2' returned a non-zero code: 1
```

So I'm updating apk add to include `bash 5.1.16`, and bumping `lein-cljfmt` as well.